### PR TITLE
Updating pipfile with latest packages but for python 3.6 

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,10 +6,10 @@ verify_ssl = true
 [dev-packages]
 
 [packages]
-requests = "*"
-pyyaml = "*"
-jinja2 = "*"
+requests = ">=2.20.0"
 urllib3 = ">=1.24.2"
+jinja2 = ">=2.10.1"
+pyyaml = "*"
 
 [requires]
-python_version = "3.7"
+python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8aa080f71ecda19c0d8c2958093f27ac5c0388d304087788504c6eb67c02faf9"
+            "sha256": "ebb0ce7c1fe8393092ed8206ae0b31511614850b90f77133a53dae04a88c2670"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.7"
+            "python_version": "3.6"
         },
         "sources": [
             {

--- a/bin/buildkite
+++ b/bin/buildkite
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.7
+#!/usr/bin/env python3.6
 """CRUD for Buildkite pipelines. Reads from YAML files."""
 
 import argparse


### PR DESCRIPTION
This change is to revert back to python 3.6 since Amazon Linux doesn't support python 3.7 yet. This change still satisfies the security vulnerabilities that were reported by GitHub.