### PR TITLE
Update to privup script to use AWS Secrets Manager for API token

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,7 @@ Agent environments are bootstrapped from a script. Visit the parameters of any s
 ## Adding secrets
 
 Secrets are pulled in from the `/env` file in the managed secrets S3 bucket. Each stack has its own bucket. Download the file, edit it, and upload it back to commit changes. No further action is necessary.
+
+## privup script is used to upload packages to s3 bucket deb.openswitch.net
+
+This script contacts AWS s3 buckets to upload packages. It also contacts the Secrets Manager for API access tokens.

--- a/bin/privup
+++ b/bin/privup
@@ -36,7 +36,9 @@ init() {
   printf "[INFO] Waiting for builds to finish" >&2
 
   while true; do
-    running_builds="$(curl -ns --anyauth 'https://api.buildkite.com/v2/builds?state=running' | jq 'length')"
+    # API Access token for account opx in Buildkite stored in Secrets Manager.
+    secrets_mgr_token="$(aws secretsmanager get-secret-value --secret-id BuildkiteAPIToken | jq -r .'SecretString')"
+    running_builds="$(curl -s -H "Authorization: Bearer $secrets_mgr_token" "https://api.buildkite.com/v2/builds?state=running")"
     if [[ "$running_builds" -gt 0 ]]; then
       printf "." >&2
       sleep 5


### PR DESCRIPTION
This is one of the scripts that talk to the Buildkite API. Since buildkite has taken away the basic authentication access, we have to move towards using API tokens. The API tokens are saved in AWS Secrets Manager.